### PR TITLE
EPODvcIs: Parse enums from strings in TryGetCustomData

### DIFF
--- a/Loop54.Shared/Properties/AssemblyInfo.cs
+++ b/Loop54.Shared/Properties/AssemblyInfo.cs
@@ -45,7 +45,7 @@ namespace Loop54.Properties
     {
         public const string Major = "5";
         public const string Minor = "7";
-        public const string Patch = "0";
+        public const string Patch = "1";
 
         public const string Full = Major + "." + Minor + "." + Patch;
     }
@@ -113,3 +113,4 @@ namespace Loop54.Properties
 // 5.6.1 Upgraded System.Text.Encodings.Web to 4.5.1
 // 5.6.2 Updated NuGet package specification with correct dependency versions, added icon
 // 5.7.0 Added redirect target to the search response
+// 5.7.1 Parse enums from strings in TryGetCustomData

--- a/Loop54.Tests.Shared/Model/Response.cs
+++ b/Loop54.Tests.Shared/Model/Response.cs
@@ -11,6 +11,7 @@ namespace Loop54.Tests.Model
     public class Response
     {
         private const string ResponseJsonWithCustomData = "{ \"customData\": { \"stringData\": \"Hjalmar Söderberg\", \"doubleData\": 13.37, " +
+            "\"enumData\": \"wednesday\", " +
             "\"complexData\": { \"count\": 3, \"facets\": [], \"items\": [{\"id\": \"sku-123\", \"type\": \"product\"}] } } }";
 
         private const string ResponseJsonWithoutCustomData = "{}";
@@ -22,6 +23,7 @@ namespace Loop54.Tests.Model
 
             Assert.AreEqual("Hjalmar Söderberg", responseObject.GetCustomDataOrDefault<string>("stringData"));
             Assert.AreEqual(13.37d, responseObject.GetCustomDataOrDefault<double>("doubleData"));
+            Assert.AreEqual(DayOfWeek.Wednesday, responseObject.GetCustomDataOrDefault<DayOfWeek>("enumData"));
             var complex = responseObject.GetCustomDataOrDefault<EntityCollection>("complexData");
             Assert.AreEqual(3, complex.Count);
             Assert.AreEqual(0, complex.Facets.Count);
@@ -41,6 +43,7 @@ namespace Loop54.Tests.Model
 
             Assert.IsNull(responseObject.GetCustomDataOrDefault<string>("stringData"));
             Assert.AreEqual(default(double), responseObject.GetCustomDataOrDefault<double>("doubleData"));
+            Assert.AreEqual(default(DayOfWeek), responseObject.GetCustomDataOrDefault<DayOfWeek>("enumData"));
             Assert.IsNull(responseObject.GetCustomDataOrDefault<EntityCollection>("complexData"));
         }
         
@@ -51,6 +54,7 @@ namespace Loop54.Tests.Model
 
             Assert.AreEqual("Hjalmar Söderberg", responseObject.GetCustomDataOrThrow<string>("stringData"));
             Assert.AreEqual(13.37d, responseObject.GetCustomDataOrThrow<double>("doubleData"));
+            Assert.AreEqual(DayOfWeek.Wednesday, responseObject.GetCustomDataOrThrow<DayOfWeek>("enumData"));
             var complex = responseObject.GetCustomDataOrThrow<EntityCollection>("complexData");
             Assert.AreEqual(3, complex.Count);
             Assert.AreEqual(0, complex.Facets.Count);
@@ -70,6 +74,7 @@ namespace Loop54.Tests.Model
 
             Assert.Throws<CustomDataException>(() => responseObject.GetCustomDataOrThrow<string>("stringData"));
             Assert.Throws<CustomDataException>(() => responseObject.GetCustomDataOrThrow<double>("doubleData"));
+            Assert.Throws<CustomDataException>(() => responseObject.GetCustomDataOrThrow<double>("enumData"));
             Assert.Throws<CustomDataException>(() => responseObject.GetCustomDataOrThrow<EntityCollection>("complexData"));
         }
 


### PR DESCRIPTION
This allows the caller to use `GetCustomDataOrThrow<AnEnumType>`, as was previously possibly with API V2.