### PR TITLE
uImrbntf: Add support for "getIndexedAttributes" API call

### DIFF
--- a/Loop54.NetCoreCodeExamples/Controllers/SyncController.cs
+++ b/Loop54.NetCoreCodeExamples/Controllers/SyncController.cs
@@ -1,4 +1,4 @@
-﻿using Loop54.Http;
+using Loop54.Http;
 using Loop54.Model.Request;
 using Loop54.Model.Response;
 using Microsoft.AspNetCore.Mvc;
@@ -18,11 +18,8 @@ namespace Loop54.NetCoreCodeExamples.Controllers
         {
             // CODE SAMPLE sync BEGIN
             //create a client with a null client info provider (because we don't need user context when syncing)
-            ILoop54Client client = new Loop54Client(new RequestManager(new Loop54Settings("https://helloworld.54proxy.com")
-            {
-                ApiKey = "TestApiKey"
-            }
-            ), new NullClientInfoProvider());
+            ILoop54Client client = new Loop54Client(new RequestManager(new Loop54Settings("https://helloworld.54proxy.com", "TestApiKey")),
+                new NullClientInfoProvider());
 
             Response response = client.Sync();
             // CODE SAMPLE END

--- a/Loop54.Shared/ILoop54Client.cs
+++ b/Loop54.Shared/ILoop54Client.cs
@@ -297,6 +297,26 @@ namespace Loop54
 
         #endregion
 
+        #region GetIndexedAttributes
+
+        /// <summary>Make a getIndexedAttributes call to the engine. Will return information about attributes, indexed and non-indexed.</summary>
+        /// <param name="request">Contains the request data to send to the engine.</param>
+        GetIndexedAttributesResponse GetIndexedAttributes(GetIndexedAttributesRequest request);
+
+        /// <summary>Make a getIndexedAttributes call to the engine. Will return information about attributes, indexed and non-indexed.</summary>
+        /// <param name="request">Contains the request data to send to the engine.</param>
+        Task<GetIndexedAttributesResponse> GetIndexedAttributesAsync(GetIndexedAttributesRequest request);
+
+        /// <summary>Make a getIndexedAttributes call to the engine. Will return information about attributes, indexed and non-indexed.</summary>
+        /// <param name="request">Contains the request data to send to the engine. Wrapped in a RequestContainer with optional user data overrides.</param>
+        GetIndexedAttributesResponse GetIndexedAttributes(RequestContainer<GetIndexedAttributesRequest> request);
+
+        /// <summary>Make a getIndexedAttributes call to the engine. Will return information about attributes, indexed and non-indexed.</summary>
+        /// <param name="request">Contains the request data to send to the engine. Wrapped in a RequestContainer with optional user data overrides.</param>
+        Task<GetIndexedAttributesResponse> GetIndexedAttributesAsync(RequestContainer<GetIndexedAttributesRequest> request);
+
+        #endregion
+
         #region CustomCall
 
         /// <summary>

--- a/Loop54.Shared/Loop54.Shared.projitems
+++ b/Loop54.Shared/Loop54.Shared.projitems
@@ -12,7 +12,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)ILoop54ClientProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Loop54ClientProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Loop54SettingsCollection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Request\GetIndexedAttributesRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Request\Parameters\Filters\FilterComparisonMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Response\GetIndexedAttributesResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NullClientInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NullClientInfoProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RequestContainer.cs" />

--- a/Loop54.Shared/Loop54Client.cs
+++ b/Loop54.Shared/Loop54Client.cs
@@ -1,4 +1,3 @@
-using Loop54.AspNet;
 using Loop54.Http;
 using Loop54.Model.Request;
 using Loop54.Model.Response;
@@ -27,6 +26,7 @@ namespace Loop54
         private const string GetBasketRecommendationsRequestName = "getBasketRecommendations";
         private const string CreateEventsRequestName = "createEvents";
         private const string SyncRequestName = "sync";
+        private const string GetIndexedAttributesRequestName = "getIndexedAttributes";
 
         private readonly IRequestManager _requestManager;
         private readonly IRemoteClientInfoProvider _remoteClientInfoProvider;
@@ -110,12 +110,24 @@ namespace Loop54
         public async Task<Response> SyncAsync(RequestContainer<Request> request)
             => await CallEngineWithinClientContextAsync<Request, Response>(SyncRequestName, request, true);
 
+        public GetIndexedAttributesResponse GetIndexedAttributes(GetIndexedAttributesRequest request)
+            => GetIndexedAttributes(request.Wrap());
+        public GetIndexedAttributesResponse GetIndexedAttributes(RequestContainer<GetIndexedAttributesRequest> request)
+            => CallEngineWithinClientContext<GetIndexedAttributesRequest, GetIndexedAttributesResponse>(GetIndexedAttributesRequestName, request);
+        public async Task<GetIndexedAttributesResponse> GetIndexedAttributesAsync(GetIndexedAttributesRequest request)
+            => await GetIndexedAttributesAsync(request.Wrap());
+        public async Task<GetIndexedAttributesResponse> GetIndexedAttributesAsync(RequestContainer<GetIndexedAttributesRequest> request)
+            => await CallEngineWithinClientContextAsync<GetIndexedAttributesRequest, GetIndexedAttributesResponse>(GetIndexedAttributesRequestName, request);
+
         public Response CustomCall(string name, Request request) => CustomCall(name, request.Wrap());
         public Response CustomCall(string name, RequestContainer<Request> request) => CallEngineWithinClientContext<Request, Response>(name, request);
         public async Task<Response> CustomCallAsync(string name, Request request) => await CustomCallAsync(name, request.Wrap());
         public async Task<Response> CustomCallAsync(string name, RequestContainer<Request> request) => await CallEngineWithinClientContextAsync<Request, Response>(name, request);
 
-        private TResponse CallEngineWithinClientContext<TRequest, TResponse>(string requestName, RequestContainer<TRequest> request, bool allowNullRequest = false) where TResponse : Response where TRequest : Request
+        private TResponse CallEngineWithinClientContext<TRequest, TResponse>(string requestName, RequestContainer<TRequest> request,
+            bool allowNullRequest = false)
+            where TResponse : Response
+            where TRequest : Request
         {
             request = ValidateRequest(requestName, request, allowNullRequest);
             UserMetaData metaData = PrepareRequest(requestName, request);
@@ -132,14 +144,18 @@ namespace Loop54
             }
         }
 
-        private async Task<TResponse> CallEngineWithinClientContextAsync<TRequest, TResponse>(string requestName, RequestContainer<TRequest> request, bool allowNullRequest = false) where TResponse : Response where TRequest : Request
+        private async Task<TResponse> CallEngineWithinClientContextAsync<TRequest, TResponse>(string requestName, RequestContainer<TRequest> request,
+            bool allowNullRequest = false)
+            where TResponse : Response
+            where TRequest : Request
         {
             request = ValidateRequest(requestName, request, allowNullRequest);
             UserMetaData metaData = PrepareRequest(requestName, request);
             return await _requestManager.CallEngineAsync<TRequest, TResponse>(requestName, request.Request, metaData);
         }
 
-        private RequestContainer<TRequest> ValidateRequest<TRequest>(string requestName, RequestContainer<TRequest> request, bool allowNullRequest) where TRequest : Request
+        private RequestContainer<TRequest> ValidateRequest<TRequest>(string requestName, RequestContainer<TRequest> request, bool allowNullRequest)
+            where TRequest : Request
         {
             if (requestName == null)
                 throw new ArgumentNullException(nameof(requestName));

--- a/Loop54.Shared/Loop54Settings.cs
+++ b/Loop54.Shared/Loop54Settings.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Loop54
 {
@@ -9,13 +7,12 @@ namespace Loop54
     /// </summary>
     public class Loop54Settings
     {
-        /// <summary>
-        /// Constructor
-        /// </summary>
         /// <param name="endpoint">The endpoint of the Loop54 search engine. If you don't have this please contact customer support.</param>
-        public Loop54Settings(string endpoint)
+        /// <param name="apiKey">The API key authenticating you as a trusted caller. If you don't have this please contact customer support.</param>
+        public Loop54Settings(string endpoint, string apiKey = null)
         {
             Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            ApiKey = apiKey;
         }
 
         /// <summary>
@@ -24,7 +21,7 @@ namespace Loop54
         public string Endpoint { get; set; }
 
         /// <summary>
-        /// The api key authenticating you as a trusted caller. If you don't have this please contact customer support.
+        /// The API key authenticating you as a trusted caller. If you don't have this please contact customer support.
         /// </summary>
         public string ApiKey { get; set; } = null;
 

--- a/Loop54.Shared/Model/Entity.cs
+++ b/Loop54.Shared/Model/Entity.cs
@@ -42,8 +42,7 @@ namespace Loop54.Model
             }
             set
             {
-                //In the engine attributes are treated case-insensitive.
-                _internalAttributeMapping = value?.ToDictionary(k => k.Name, v => v, StringComparer.OrdinalIgnoreCase);
+                _internalAttributeMapping = value?.ToDictionary(k => k.Name, v => v, EntityAttribute.NameComparer);
             }
         }
 

--- a/Loop54.Shared/Model/EntityAttribute.cs
+++ b/Loop54.Shared/Model/EntityAttribute.cs
@@ -11,6 +11,9 @@ namespace Loop54.Model
     /// </summary>
     public class EntityAttribute
     {
+        /// <summary>Attribute names are treated as case-insensitive by the engine, though the case received should be preserved preserved.</summary>
+        public static readonly StringComparer NameComparer = StringComparer.OrdinalIgnoreCase;
+
         /// <summary>
         /// Name of the attribute. For instance "Price", "Name" or "Category".
         /// </summary>

--- a/Loop54.Shared/Model/Request/GetIndexedAttributesRequest.cs
+++ b/Loop54.Shared/Model/Request/GetIndexedAttributesRequest.cs
@@ -1,0 +1,7 @@
+namespace Loop54.Model.Request
+{
+    /// <summary>Request to the getIndexedAttributes API method of the Loop54 e-commerce search engine.</summary>
+    public class GetIndexedAttributesRequest : Request
+    {
+    }
+}

--- a/Loop54.Shared/Model/Response/GetIndexedAttributesResponse.cs
+++ b/Loop54.Shared/Model/Response/GetIndexedAttributesResponse.cs
@@ -1,0 +1,12 @@
+namespace Loop54.Model.Response
+{
+    /// <summary>The results of a getIndexedAttributes request.</summary>
+    public class GetIndexedAttributesResponse : Response
+    {
+        /// <summary>Entity attributes that the engine currently has in memory, which are available for filtering, sorting and faceting.</summary>
+        public string[] Attributes { get; set; }
+
+        /// <summary>Attributes that are indexed by the engine and can be used in a getEntitiesByAttribute request.</summary>
+        public string[] IndexedAttributes { get; set; }
+    }
+}

--- a/Loop54.Shared/Properties/AssemblyInfo.cs
+++ b/Loop54.Shared/Properties/AssemblyInfo.cs
@@ -44,8 +44,8 @@ namespace Loop54.Properties
     internal static class PackageSemanticVersion
     {
         public const string Major = "5";
-        public const string Minor = "7";
-        public const string Patch = "1";
+        public const string Minor = "8";
+        public const string Patch = "0";
 
         public const string Full = Major + "." + Minor + "." + Patch;
     }
@@ -114,3 +114,4 @@ namespace Loop54.Properties
 // 5.6.2 Updated NuGet package specification with correct dependency versions, added icon
 // 5.7.0 Added redirect target to the search response
 // 5.7.1 Parse enums from strings in TryGetCustomData
+// 5.8.0 Added support for "getIndexedAttributes" API call

--- a/Loop54.Test.AspNetCore/Controllers/GetIndexedAttributesController.cs
+++ b/Loop54.Test.AspNetCore/Controllers/GetIndexedAttributesController.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Loop54.Model.Request;
+using Loop54.Test.AspNetCore.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Loop54.Test.AspNetCore.Controllers
+{
+    public class GetIndexedAttributesController : Controller
+    {
+        private readonly ILoop54Client _loop54Client;
+
+        public GetIndexedAttributesController(ILoop54Client loop54Client)
+        {
+            _loop54Client = loop54Client;
+        }
+        
+        [HttpGet]
+        public async Task<IActionResult> Index()
+        {
+            var response = await _loop54Client.GetIndexedAttributesAsync(new GetIndexedAttributesRequest());
+
+            return View(new GetIndexedAttributesViewModel
+            {
+                Attributes = response.Attributes,
+                IndexedAttributes = response.IndexedAttributes
+            });
+        }
+    }
+}

--- a/Loop54.Test.AspNetCore/Models/GetIndexedAttributesViewModel.cs
+++ b/Loop54.Test.AspNetCore/Models/GetIndexedAttributesViewModel.cs
@@ -1,0 +1,8 @@
+namespace Loop54.Test.AspNetCore.Models
+{
+    public class GetIndexedAttributesViewModel
+    {
+        public string[] Attributes { get; internal set; }
+        public string[] IndexedAttributes { get; internal set; }
+    }
+}

--- a/Loop54.Test.AspNetCore/Startup.cs
+++ b/Loop54.Test.AspNetCore/Startup.cs
@@ -26,7 +26,8 @@ namespace Loop54.Test.AspNetCore
             //by adding them to the Loop54SettingsCollection. Note that if adding more than one named Loop54Setting the 
             //ILoop54Client interface wont be injectable. but instead you need to inject the ILoop54ClientProvider and use 
             //the GetNamed method, providing the same name used here, as seen in the SearchController.
-            services.AddLoop54(Loop54SettingsCollection.Create().Add("English", "https://helloworld.54proxy.com"));
+            var loop54Settings = new Loop54Settings("https://helloworld.54proxy.com", "TestApiKey");
+            services.AddLoop54(Loop54SettingsCollection.Create().Add("English", loop54Settings));
             //Could be replaced with:
             //services.AddLoop54("https://helloworld.54proxy.com");
             //For the most basic implementations.

--- a/Loop54.Test.AspNetCore/Views/GetIndexedAttributes/Index.cshtml
+++ b/Loop54.Test.AspNetCore/Views/GetIndexedAttributes/Index.cshtml
@@ -1,0 +1,20 @@
+@using Loop54.Test.AspNetCore.Models
+@model GetIndexedAttributesViewModel
+@{
+    ViewData["PageName"] = "GetIndexedAttributes";
+}
+<h3>@Model.Attributes.Length available attributes</h3>
+<ol>
+    @foreach (string name in Model.Attributes)
+    {
+        <li>@name</li>
+    }
+</ol>
+
+<h3>@Model.IndexedAttributes.Length indexed attributes</h3>
+<ol>
+    @foreach (string name in Model.IndexedAttributes)
+    {
+        <li>@name</li>
+    }
+</ol>

--- a/Loop54.Test.AspNetCore/Views/Home/Index.cshtml
+++ b/Loop54.Test.AspNetCore/Views/Home/Index.cshtml
@@ -3,11 +3,12 @@
     ViewData["PageName"] = "Index";
 }
 <ul>
-    <li><a asp-controller="Search" asp-action="Index">Search</a></li>
-    <li><a asp-controller="Search" asp-action="WithCustomData">Search with custom data</a></li>
-    <li><a asp-controller="GetEntities" asp-action="Index">GetEntities</a></li>
-    <li><a asp-controller="GetRelatedEntities" asp-action="Index">GetRelatedEntities</a></li>
-    <li><a asp-controller="GetEntitiesByAttribute" asp-action="Index">GetEntitiesByAttribute</a></li>
     <li><a asp-controller="AutoComplete" asp-action="Index">AutoComplete</a></li>
     <li><a asp-controller="CreateEvents" asp-action="Index">CreateEvents</a></li>
+    <li><a asp-controller="GetEntities" asp-action="Index">GetEntities</a></li>
+    <li><a asp-controller="GetEntitiesByAttribute" asp-action="Index">GetEntitiesByAttribute</a></li>
+    <li><a asp-controller="GetIndexedAttributes" asp-action="Index">GetIndexedAttributes</a></li>
+    <li><a asp-controller="GetRelatedEntities" asp-action="Index">GetRelatedEntities</a></li>
+    <li><a asp-controller="Search" asp-action="Index">Search</a></li>
+    <li><a asp-controller="Search" asp-action="WithCustomData">Search with custom data</a></li>
 </ul>

--- a/Loop54.Test.AspNetMvc/Controllers/GetIndexedAttributesController.cs
+++ b/Loop54.Test.AspNetMvc/Controllers/GetIndexedAttributesController.cs
@@ -1,0 +1,24 @@
+using System.Web.Mvc;
+using Loop54.AspNet;
+using Loop54.Model.Request;
+using Loop54.Test.AspNetMvc.Models;
+
+namespace Loop54.Test.AspNetMvc.Controllers
+{
+    public class GetIndexedAttributesController : Controller
+    {
+        private readonly ILoop54Client _loop54Client = Loop54ClientManager.Client();
+
+        [HttpGet]
+        public ActionResult Index()
+        {
+            var response = _loop54Client.GetIndexedAttributes(new GetIndexedAttributesRequest());
+
+            return View(new GetIndexedAttributesViewModel
+            {
+                Attributes = response.Attributes,
+                IndexedAttributes = response.IndexedAttributes
+            });
+        }
+    }
+}

--- a/Loop54.Test.AspNetMvc/Global.asax.cs
+++ b/Loop54.Test.AspNetMvc/Global.asax.cs
@@ -11,7 +11,7 @@ namespace Loop54.Test.AspNetMvc
             //Will configure the client to point to the provided endpoint. Will thereafter serve a singleton 
             //instance when calling Client method. If calling StartUp multiple times, a new instance of the 
             //client will be created each time.
-            Loop54ClientManager.StartUp("https://helloworld.54proxy.com");
+            Loop54ClientManager.StartUp(new Loop54Settings("https://helloworld.54proxy.com", "TestApiKey"));
 
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);

--- a/Loop54.Test.AspNetMvc/Loop54.Test.AspNetMvc.csproj
+++ b/Loop54.Test.AspNetMvc/Loop54.Test.AspNetMvc.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Controllers\CreateEventsController.cs" />
     <Compile Include="Controllers\GetEntitiesByAttributeController.cs" />
     <Compile Include="Controllers\GetEntitiesController.cs" />
+    <Compile Include="Controllers\GetIndexedAttributesController.cs" />
     <Compile Include="Controllers\GetRelatedEntitiesController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\SearchController.cs" />
@@ -132,6 +133,7 @@
     <Compile Include="Models\FacetViewModel.cs" />
     <Compile Include="Models\GetEntitiesByAttributeViewModel.cs" />
     <Compile Include="Models\GetEntitiesViewModel.cs" />
+    <Compile Include="Models\GetIndexedAttributesViewModel.cs" />
     <Compile Include="Models\GetRelatedEntitiesViewModel.cs" />
     <Compile Include="Models\ProductViewModel.cs" />
     <Compile Include="Models\SearchViewModel.cs" />
@@ -165,6 +167,7 @@
     <Content Include="Views\GetEntities\Index.cshtml" />
     <Content Include="Views\AutoComplete\Index.cshtml" />
     <Content Include="Views\_ViewStart.cshtml" />
+    <Content Include="Views\GetIndexedAttributes\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Loop54.NetFramework\Loop54.NetFramework.csproj">

--- a/Loop54.Test.AspNetMvc/Models/GetIndexedAttributesViewModel.cs
+++ b/Loop54.Test.AspNetMvc/Models/GetIndexedAttributesViewModel.cs
@@ -1,0 +1,8 @@
+namespace Loop54.Test.AspNetMvc.Models
+{
+    public class GetIndexedAttributesViewModel
+    {
+        public string[] Attributes { get; internal set; }
+        public string[] IndexedAttributes { get; internal set; }
+    }
+}

--- a/Loop54.Test.AspNetMvc/Views/GetIndexedAttributes/Index.cshtml
+++ b/Loop54.Test.AspNetMvc/Views/GetIndexedAttributes/Index.cshtml
@@ -1,0 +1,20 @@
+@using Loop54.Test.AspNetMvc.Models
+@model GetIndexedAttributesViewModel
+@{
+    ViewData["PageName"] = "GetIndexedAttributes";
+}
+<h3>@Model.Attributes.Length available attributes</h3>
+<ol>
+    @foreach (string name in Model.Attributes)
+    {
+        <li>@name</li>
+    }
+</ol>
+
+<h3>@Model.IndexedAttributes.Length indexed attributes</h3>
+<ol>
+    @foreach (string name in Model.IndexedAttributes)
+    {
+        <li>@name</li>
+    }
+</ol>

--- a/Loop54.Test.AspNetMvc/Views/Home/Index.cshtml
+++ b/Loop54.Test.AspNetMvc/Views/Home/Index.cshtml
@@ -3,11 +3,12 @@
     ViewData["PageName"] = "Index";
 }
 <ul>
-    <li>@Html.ActionLink("Search", "Index", "Search", null, null)</li>
-    <li>@Html.ActionLink("Search with custom data", "WithCustomData", "Search", null, null)</li>
-    <li>@Html.ActionLink("GetEntities", "Index", "GetEntities", null, null)</li>
-    <li>@Html.ActionLink("GetRelatedEntities", "Index", "GetRelatedEntities", null, null)</li>
-    <li>@Html.ActionLink("GetEntitiesByAttribute", "Index", "GetEntitiesByAttribute", null, null)</li>
     <li>@Html.ActionLink("AutoComplete", "Index", "AutoComplete", null, null)</li>
     <li>@Html.ActionLink("CreateEvents", "Index", "CreateEvents", null, null)</li>
+    <li>@Html.ActionLink("GetEntities", "Index", "GetEntities", null, null)</li>
+    <li>@Html.ActionLink("GetEntitiesByAttribute", "Index", "GetEntitiesByAttribute", null, null)</li>
+    <li>@Html.ActionLink("GetIndexedAttributes", "Index", "GetIndexedAttributes", null, null)</li>
+    <li>@Html.ActionLink("GetRelatedEntities", "Index", "GetRelatedEntities", null, null)</li>
+    <li>@Html.ActionLink("Search", "Index", "Search", null, null)</li>
+    <li>@Html.ActionLink("Search with custom data", "WithCustomData", "Search", null, null)</li>
 </ul>


### PR DESCRIPTION
Including unit tests and ASP.NET examples.

This requires sending the API key, so add that to the constructor of Loop54Settings to encourage the caller to pass it in (though it remains optional for now to preserve source compatibility).