### PR TITLE
xWaaEz7U: Remove Microsoft.AspNetCore.Http.Extensions package reference

### DIFF
--- a/Loop54.NetStandard/AspNet/HttpContextInfo.cs
+++ b/Loop54.NetStandard/AspNet/HttpContextInfo.cs
@@ -1,8 +1,6 @@
 using System;
 using Loop54.User;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Net.Http.Headers;
 
 namespace Loop54.AspNet
 {
@@ -39,12 +37,12 @@ namespace Loop54.AspNet
 
         public string GetReferrer()
         {
-            return _context.Request.Headers[HeaderNames.Referer];
+            return _context.Request.Headers["Referer"];
         }
 
         public string GetUserAgent()
         {
-            return _context.Request.Headers[HeaderNames.UserAgent];
+            return _context.Request.Headers["User-Agent"];
         }
 
         public string GetRemoteIp()

--- a/Loop54.NetStandard/Loop54.NetStandard.csproj
+++ b/Loop54.NetStandard/Loop54.NetStandard.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 

--- a/Loop54.Tests.Shared/CallMethods.cs
+++ b/Loop54.Tests.Shared/CallMethods.cs
@@ -45,8 +45,6 @@ namespace Loop54.Tests
             var response = GetClient().Search(WrapRequest(new SearchRequest(query)));
             Assert.Greater(response.Results.Count, 0);
             Assert.Greater(response.Results.Items.Count, 0);
-            Assert.Greater(response.RelatedResults.Count, 0);
-            Assert.Greater(response.RelatedResults.Items.Count, 0);
         }
 
         [Test]


### PR DESCRIPTION
It is marked "deprecated" and was only needed for 2 constants - we don't need to pull in a package for that.
Fixed failing unit test to not require related results anymore.